### PR TITLE
Use port 443 for https in Server.checkRequest

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -68,7 +68,12 @@ Server.prototype.checkRequest = function(req, fn) {
   if (origin) {
     try {
       var parts = url.parse(origin);
-      parts.port = parts.port || 80;
+      parts.port = parts.port
+        ? parts.port
+        : parts.protocol === 'https:'
+        ? 443
+        : 80;
+
       var ok =
         ~this._origins.indexOf(parts.hostname + ':' + parts.port) ||
         ~this._origins.indexOf(parts.hostname + ':*') ||

--- a/test/socket.io.js
+++ b/test/socket.io.js
@@ -259,6 +259,17 @@ describe('socket.io', function(){
           done();
         });
     });
+
+    it('should default to port 443 when protocol is https', function(done) {
+      var sockets = io({ origins: 'https://foo.example:443' }).listen('54036');
+      request.get('http://localhost:54036/socket.io/default/')
+        .set('origin', 'https://foo.example')
+        .query({ transport: 'polling' })
+        .end(function (err, res) {
+          expect(res.status).to.be(200);
+          done();
+        });
+    });
   });
 
   describe('close', function(){


### PR DESCRIPTION
Currently, even if the parsed url.protocol is `https:`,
Server.checkRequest was matching against port 80. This defaults that
check to use 443 if the protocol is `https:`