### PR TITLE
Fixing Bug #1670 - Socket.prototype.leave exhibits wrong behaviour

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -242,7 +242,9 @@ Socket.prototype.leave = function(room, fn){
   this.adapter.del(this.id, room, function(err){
     if (err) return fn && fn(err);
     debug('left room %s', room);
-    self.rooms.splice(self.rooms.indexOf(room), 1);
+    if (self.rooms.indexOf(room) >= 0) {
+      self.rooms.splice(self.rooms.indexOf(room), 1);
+    }
     fn && fn(null);
   });
   return this;


### PR DESCRIPTION
A bugfix introduced to fix bug #1670 when leaving rooms still exhibits wrong and unexpected behaviour.
If the room that should be left is not found in self.rooms, indexOf returns -1, 
making the arguments of arr.splice (-1,1), meaning remove one room from the end of self.rooms.