### PR TITLE
Allow null or undefined origins when allowed origins is a function

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -62,7 +62,7 @@ Server.prototype.checkRequest = function(req, fn) {
   var origin = req.headers.origin || req.headers.referer;
 
   // file:// URLs produce a null Origin which can't be authorized via echo-back
-  if ('null' == origin) origin = '*';
+  if ('null' == origin || null == origin) origin = '*';
 
   if (!!origin && typeof(this._origins) == 'function') return this._origins(origin, fn);
   if (this._origins.indexOf('*:*') !== -1) return fn(null, true);

--- a/test/socket.io.js
+++ b/test/socket.io.js
@@ -302,6 +302,21 @@ describe('socket.io', function(){
           done();
         });
     });
+
+    it('should allow request when origin defined as function and no origin is supplied', function(done) {
+      var sockets = io({ origins: function(origin,callback){
+        if (origin == '*') {
+          return callback(null, true);
+        }
+        return callback(null, false);
+      } }).listen('54021');
+      request.get('http://localhost:54021/socket.io/default/')
+       .query({ transport: 'polling' })
+       .end(function (err, res) {
+          expect(res.status).to.be(200);
+          done();
+        });
+    });
   });
 
   describe('close', function(){


### PR DESCRIPTION
Requests without an Origin header previously caused an exception to be thrown if the allowed origins passed to the constructor was set to a dynamic function. Omitted origins are now set to an asterisk and passed properly to the origins function.

This fixes issue #1919.

A test for this case is included.