### PR TITLE
bugfix/1956 test for don't reuse same-namespace connections

### DIFF
--- a/test/socket.io.js
+++ b/test/socket.io.js
@@ -597,6 +597,23 @@ describe('socket.io', function(){
         });
       });
     });
+    
+    it('should not reuse same-namespace connections', function(done){
+      var srv = http();
+      var sio = io(srv);
+      var connections = 0;
+
+      srv.listen(function() {
+        var clientSocket1 = client(srv);
+        var clientSocket2 = client(srv);
+        sio.on('connection', function() {
+          connections++;
+          if(connections === 2) {
+            done();
+          }
+        });
+      });
+    });
   });
 
   describe('socket', function(){


### PR DESCRIPTION
this is a failing test for socket.io-client issue #1956 

the fix is located in pull request https://github.com/Automattic/socket.io-client/pull/808