### PR TITLE
improve Socket#packet and Client#packet and enable volatile and compress when broadcast

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -61,7 +61,7 @@ Client.prototype.setup = function(){
 Client.prototype.connect = function(name){
   debug('connecting to namespace %s', name);
   if (!this.server.nsps[name]) {
-    this.packet({ type: parser.ERROR, nsp: name, data : 'Invalid namespace'}, false, false, true);
+    this.packet({ type: parser.ERROR, nsp: name, data : 'Invalid namespace'});
     return;
   }
   var nsp = this.server.of(name);
@@ -133,26 +133,25 @@ Client.prototype.close = function(){
  * Writes a packet to the transport.
  *
  * @param {Object} packet object
- * @param {Boolean} whether packet is already encoded
- * @param {Boolean} whether packet is volatile
- * @param {Boolean} whether packet should be compressed
+ * @param {Object} options
  * @api private
  */
 
-Client.prototype.packet = function(packet, preEncoded, volatile, compress){
+Client.prototype.packet = function(packet, opts){
+  opts = opts || {};
   var self = this;
 
   // this writes to the actual connection
   function writeToEngine(encodedPackets) {
-    if (volatile && !self.conn.transport.writable) return;
+    if (opts.volatile && !self.conn.transport.writable) return;
     for (var i = 0; i < encodedPackets.length; i++) {
-      self.conn.write(encodedPackets[i], { compress: compress });
+      self.conn.write(encodedPackets[i], { compress: opts.compress });
     }
   }
 
   if ('open' == this.conn.readyState) {
     debug('writing packet %j', packet);
-    if(!preEncoded) { // not broadcasting, need to encode
+    if (!opts.preEncoded) { // not broadcasting, need to encode
       this.encoder.encode(packet, function (encodedPackets) { // encode, then write results to engine
         writeToEngine(encodedPackets);
       });

--- a/lib/socket.js
+++ b/lib/socket.js
@@ -132,10 +132,11 @@ Socket.prototype.emit = function(ev){
     var packet = {};
     packet.type = hasBin(args) ? parser.BINARY_EVENT : parser.EVENT;
     packet.data = args;
+    var flags = this.flags || {};
 
     // access last argument to see if it's an ACK callback
     if ('function' == typeof args[args.length - 1]) {
-      if (this._rooms || (this.flags && this.flags.broadcast)) {
+      if (this._rooms || flags.broadcast) {
         throw new Error('Callbacks are not supported when broadcasting');
       }
 
@@ -144,15 +145,18 @@ Socket.prototype.emit = function(ev){
       packet.id = this.nsp.ids++;
     }
 
-    if (this._rooms || (this.flags && this.flags.broadcast)) {
+    if (this._rooms || flags.broadcast) {
       this.adapter.broadcast(packet, {
         except: [this.id],
         rooms: this._rooms,
-        flags: this.flags
+        flags: flags
       });
     } else {
       // dispatch packet
-      this.packet(packet);
+      this.packet(packet, {
+        volatile: flags.volatile,
+        compress: flags.compress
+      });
     }
 
     // reset flags
@@ -196,14 +200,15 @@ Socket.prototype.write = function(){
  * Writes a packet.
  *
  * @param {Object} packet object
+ * @param {Object} options
  * @api private
  */
 
-Socket.prototype.packet = function(packet, preEncoded){
+Socket.prototype.packet = function(packet, opts){
   packet.nsp = this.nsp.name;
-  var volatile = this.flags && this.flags.volatile;
-  var compress = !this.flags || false !== this.flags.compress;
-  this.client.packet(packet, preEncoded, volatile, compress);
+  opts = opts || {};
+  opts.compress = false !== opts.compress;
+  this.client.packet(packet, opts);
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "engine.io": "automattic/engine.io#ddc64a",
     "socket.io-parser": "2.2.3",
     "socket.io-client": "automattic/socket.io-client#210d65",
-    "socket.io-adapter": "automattic/socket.io-adapter#ae79d8",
+    "socket.io-adapter": "nkzawa/socket.io-adapter#bd48c2f292",
     "has-binary": "0.1.6",
     "debug": "2.1.0"
   },


### PR DESCRIPTION
- Change optional arguments to an option object.
- No use of `flags` on `Socket#packet` so that we don't need to clear `flags` within it.
-  Enable volatile and compress when broadcasting

Related: https://github.com/Automattic/socket.io-adapter/pull/26