### PR TITLE
Supports flags on namespace

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -361,7 +361,7 @@ Server.prototype.close = function(){
  * Expose main namespace (/).
  */
 
-['on', 'to', 'in', 'use', 'emit', 'send', 'write', 'clients'].forEach(function(fn){
+['on', 'to', 'in', 'use', 'emit', 'send', 'write', 'clients', 'compress'].forEach(function(fn){
   Server.prototype[fn] = function(){
     var nsp = this.sockets[fn];
     return nsp.apply(this.sockets, arguments);
@@ -369,8 +369,9 @@ Server.prototype.close = function(){
 });
 
 Namespace.flags.forEach(function(flag){
-  Server.prototype.__defineGetter__(flag, function(name){
-    this.flags.push(name);
+  Server.prototype.__defineGetter__(flag, function(){
+    this.sockets.flags = this.sockets.flags || {};
+    this.sockets.flags[flag] = true;
     return this;
   });
 });

--- a/lib/namespace.js
+++ b/lib/namespace.js
@@ -29,7 +29,10 @@ exports.events = [
  * Flags.
  */
 
-exports.flags = ['json'];
+exports.flags = [
+  'json',
+  'volatile'
+];
 
 /**
  * `EventEmitter#emit` reference.
@@ -250,5 +253,19 @@ Namespace.prototype.write = function(){
 
 Namespace.prototype.clients = function(fn){
   this.adapter.clients(this.rooms, fn);
+  return this;
+};
+
+/**
+ * Sets the compress flag.
+ *
+ * @param {Boolean} if `true`, compresses the sending data
+ * @return {Socket} self
+ * @api public
+ */
+
+Namespace.prototype.compress = function(compress){
+  this.flags = this.flags || {};
+  this.flags.compress = compress;
   return this;
 };

--- a/test/socket.io.js
+++ b/test/socket.io.js
@@ -405,6 +405,12 @@ describe('socket.io', function(){
       expect(sio.emit).to.be.a('function');
       expect(sio.send).to.be.a('function');
       expect(sio.write).to.be.a('function');
+      expect(sio.clients).to.be.a('function');
+      expect(sio.compress).to.be.a('function');
+      expect(sio.json).to.be(sio);
+      expect(sio.volatile).to.be(sio);
+      expect(sio.sockets.flags).to.eql({ json: true, volatile: true });
+      delete sio.sockets.flags;
     });
 
     it('should automatically connect', function(done){
@@ -729,6 +735,87 @@ describe('socket.io', function(){
           done();
         });
       }
+    });
+
+    it('should not emit volatile event after regular event', function(done) {
+      var srv = http();
+      var sio = io(srv);
+
+      var counter = 0;
+      srv.listen(function(){
+        sio.of('/chat').on('connection', function(s){
+          // Wait to make sure there are no packets being sent for opening the connection
+          setTimeout(function() {
+            sio.of('/chat').emit('ev', 'data');
+            sio.of('/chat').volatile.emit('ev', 'data');
+          }, 20);
+        });
+
+        var socket = client(srv, '/chat');
+        socket.on('ev', function() {
+          counter++;
+        });
+      });
+
+      setTimeout(function() {
+        expect(counter).to.be(1);
+        done();
+      }, 200);
+    });
+
+    it('should emit volatile event', function(done) {
+      var srv = http();
+      var sio = io(srv);
+
+      var counter = 0;
+      srv.listen(function(){
+        sio.of('/chat').on('connection', function(s){
+          // Wait to make sure there are no packets being sent for opening the connection
+          setTimeout(function() {
+            sio.of('/chat').volatile.emit('ev', 'data');
+          }, 20);
+        });
+
+        var socket = client(srv, '/chat');
+        socket.on('ev', function() {
+          counter++;
+        });
+      });
+
+      setTimeout(function() {
+        expect(counter).to.be(1);
+        done();
+      }, 200);
+    });
+
+    it('should enable compression by default', function(done){
+      var srv = http();
+      var sio = io(srv);
+      srv.listen(function(){
+        var socket = client(srv, '/chat');
+        sio.of('/chat').on('connection', function(s){
+          s.conn.once('packetCreate', function(packet) {
+            expect(packet.options.compress).to.be(true);
+            done();
+          });
+          sio.of('/chat').emit('woot', 'hi');
+        });
+      });
+    });
+
+    it('should disable compression', function(done){
+      var srv = http();
+      var sio = io(srv);
+      srv.listen(function(){
+        var socket = client(srv, '/chat');
+        sio.of('/chat').on('connection', function(s){
+          s.conn.once('packetCreate', function(packet) {
+            expect(packet.options.compress).to.be(false);
+            done();
+          });
+          sio.of('/chat').compress(false).emit('woot', 'hi');
+        });
+      });
     });
   });
 


### PR DESCRIPTION
Add `volatile` and `compress()` to namespace including aliases for `Server`.

Note: required to merge https://github.com/Automattic/socket.io/pull/2006 to pass all tests. 

Related: https://github.com/Automattic/socket.io/issues/1952, https://github.com/Automattic/socket.io/issues/1741, https://github.com/Automattic/socket.io-client/issues/742