### PR TITLE
Let adapter.add find connected socket

### DIFF
--- a/lib/socket.js
+++ b/lib/socket.js
@@ -272,9 +272,9 @@ Socket.prototype.leaveAll = function(){
 
 Socket.prototype.onconnect = function(){
   debug('socket connected - writing packet');
+  this.nsp.connected[this.id] = this;
   this.join(this.id);
   this.packet({ type: parser.CONNECT });
-  this.nsp.connected[this.id] = this;
 };
 
 /**


### PR DESCRIPTION
When a socket connects, it joins its own room, resulting in a call to adapter.add.
The adapter in turn should be able to find the socket by id.